### PR TITLE
Add PKGBUILD for Amazon's CodeDeploy agent

### DIFF
--- a/etc/codedeploy/.gitignore
+++ b/etc/codedeploy/.gitignore
@@ -1,0 +1,4 @@
+/*.deb
+/*.tar.*
+/pkg
+/src

--- a/etc/codedeploy/Makefile
+++ b/etc/codedeploy/Makefile
@@ -1,0 +1,13 @@
+.PHONY: clean install uninstall
+
+clean:
+	rm -rf pkg src
+
+pkg:
+	makepkg --force
+
+install:
+	makepkg --force --syncdeps --install
+
+uninstall:
+	sudo pacman -Rs codedeploy-agent

--- a/etc/codedeploy/PKGBUILD
+++ b/etc/codedeploy/PKGBUILD
@@ -1,0 +1,43 @@
+# Maintainer: James Conroy-Finn <james@invetica.co.uk>
+pkgname=codedeploy-agent
+pkgver=1.0_1.1458
+pkgrel=1
+pkgdesc="AWS CodeDeploy is a deployment service that enables developers to automate the deployment of applications to instances and to update the applications as required."
+arch=('i686' 'x86_64')
+url="https://aws.amazon.com/documentation/codedeploy/"
+license=('APACHE')
+groups=()
+depends=('ruby')
+source=(https://aws-codedeploy-eu-west-1.s3-eu-west-1.amazonaws.com/releases/${pkgname}_${pkgver//_/-}_all.deb)
+md5sums=('78540a9e2fa0f79820a3b2b7ca998e45')
+noextract=()
+
+prepare() {
+  cd "$srcdir"
+  tar -xf data.tar.gz
+}
+
+# build() {
+#   cd "$srcdir"
+# }
+
+# check() {
+#   cd "$srcdir"
+# }
+
+package() {
+  cd "$srcdir"
+
+  install -dm755 "$pkgdir"/opt/
+  cp -R "${srcdir}"/opt/codedeploy-agent "${pkgdir}/opt/"
+
+  install -Dm744 \
+      "$srcdir"/etc/codedeploy-agent/conf/codedeployagent.yml \
+      "$pkgdir"/etc/codedeploy-agent/conf/codedeployagent.yml
+
+  install -Dm744 \
+      "$srcdir"/etc/init.d/codedeploy-agent.service \
+      "$pkgdir"/usr/lib/systemd/system/codedeploy-agent.service
+}
+
+# vim:set ts=2 sw=2 et:

--- a/etc/codedeploy/README.org
+++ b/etc/codedeploy/README.org
@@ -1,0 +1,136 @@
+#+TITLE: CodeDeploy Arch Package
+#+PROPERTY: header-args :var region="eu-west-1", bucket="aws-codedeploy-eu-west-1", version="latest/VERSION"
+
+* Getting the install script
+Amazon say to install Ruby, wget and then download an installation script from a
+region-specific bucket.
+
+In our case we want to start by pulling down the install script to see what it
+does.
+
+#+BEGIN_SRC shell
+  curl https://aws-codedeploy-eu-central-1.s3.amazonaws.com/latest/install > install.rb
+#+END_SRC
+
+#+RESULTS:
+
+The installation script is written in Ruby, and will be downloaded to
+[[file:install.rb][install.rb]]. I've added it to the repo so we can keep track of any changes that
+may occur in future more easily.
+
+* Poking around
+[[https://docs.aws.amazon.com/codedeploy/latest/userguide/codedeploy-agent-operations-install-ubuntu.html][Amazon's docs]] recommend running the following to install CodeDeploy:
+
+#+BEGIN_SRC shell
+sudo apt-get update
+sudo apt-get install ruby # Or ruby2.0 on older versions of Ubuntu.
+sudo apt-get install wget
+cd /home/ubuntu
+wget https://bucket-name.s3.amazonaws.com/latest/install
+chmod +x ./install
+sudo ./install auto
+#+END_SRC
+
+The install script checks you have a supported Ruby version where it currently
+supports the following versions:
+
+#+BEGIN_SRC shell :results output verbatim
+  grep -A 2 'def supported_ruby_versions' install.rb
+#+END_SRC
+
+#+RESULTS:
+:   def supported_ruby_versions
+:     ['2.4', '2.3', '2.2', '2.1', '2.0']
+:   end
+
+The script may have to be run inside AWS because it looks up availability zones
+etc. via a self-assigned (so that hosts can communicate without DHCP)
+~169.254.169.254~ address.
+
+There's one big script wrapped inside a ~begin/rescue~ block. Methods are
+defined outside of any explicit class.
+
+The ~auto~ argument runs code that will try to detect the OS package manager,
+which it sets via ~@type = "rpm"~ etc.
+
+Ultimately, ~install_from_s3~ is called with a region, bucket, version file key,
+and some additional optional arguments.
+
+#+BEGIN_SRC shell :results output verbatim
+  grep -B 1 'install_from_s3' install.rb | tail -n +3 # To get rid of the def install_from_s3
+#+END_SRC
+
+#+RESULTS:
+: --
+:       install_cmd = ['/usr/bin/yum', '-y', 'localinstall']
+:       install_from_s3(region, bucket, version_file_key, @type, install_cmd)
+: --
+:       install_cmd = ['/usr/bin/gdebi', '-n', '-o', 'Dpkg::Options::=--force-confdef', '-o', 'Dkpg::Options::=--force-confold']
+:       install_from_s3(region, bucket, version_file_key, @type, install_cmd)
+: --
+:     install_cmd = ['/usr/bin/zypper', 'install', '-n']
+:     install_from_s3(region, bucket, version_file_key, 'rpm', install_cmd)
+
+** Getting CodeDeploy version info
+#+BEGIN_SRC ruby
+  region = get_region
+  bucket = "aws-codedeploy-#{region}"
+  version_file_key = 'latest/VERSION'
+#+END_SRC
+
+#+BEGIN_SRC ruby
+  def get_region
+    @log.info('Checking AWS_REGION environment variable for region information...')
+    region = ENV['AWS_REGION']
+    return region if region
+
+    @log.info('Checking EC2 metadata service for region information...')
+    region = get_ec2_metadata_region
+    return region if region
+
+    @log.info('Using fail-safe default region: us-east-1')
+    return 'us-east-1'
+  end
+#+END_SRC
+
+There's a version file we want to get our hands on.
+
+#+BEGIN_SRC shell :results output verbatim
+  curl https://$bucket.s3-$region.amazonaws.com/$version | jq .
+#+END_SRC
+
+#+RESULTS:
+: {
+:   "rpm": "releases/codedeploy-agent-1.0-1.1458.noarch.rpm",
+:   "deb": "releases/codedeploy-agent_1.0-1.1458_all.deb",
+:   "msi": "releases/codedeploy-agent-1.0.1.1458.msi"
+: }
+
+** Debian package
+Let's download the Debian pkg and see what's inside!
+
+#+BEGIN_SRC shell :results output raw
+  echo https://$bucket.s3-$region.amazonaws.com/releases/codedeploy-agent_1.0-1.1458_all.deb
+#+END_SRC
+
+#+NAME: debian-url
+#+RESULTS:
+https://aws-codedeploy-eu-west-1.s3-eu-west-1.amazonaws.com/releases/codedeploy-agent_1.0-1.1458_all.deb
+
+#+BEGIN_SRC shell
+  curl https://$bucket.s3-$region.amazonaws.com/releases/codedeploy-agent_1.0-1.1458_all.deb > codedeploy-agent.deb
+#+END_SRC
+
+#+RESULTS:
+
+Inside the Debian package there's a ~data.tar.gz`~ archive with all the
+CodeDeploy code inside.
+
+*** Listing contents
+#+BEGIN_SRC shell :results output verbatim
+  ar -x codedeploy-agent.deb
+  # We only need the data.tar.gz
+  rm control.tar.gz debian-binary
+  tar -tvf data.tar.gz
+  rm data.tar.gz
+#+END_SRC

--- a/etc/codedeploy/install.rb
+++ b/etc/codedeploy/install.rb
@@ -1,0 +1,405 @@
+#!/usr/bin/env ruby
+
+##################################################################
+# This part of the code might be running on Ruby versions other
+# than 2.0. Testing on multiple Ruby versions is required for
+# changes to this part of the code.
+##################################################################
+
+class Proxy
+  instance_methods.each do |m|
+    undef_method m unless m =~ /(^__|^send$|^object_id$)/
+  end
+
+  def initialize(*targets)
+    @targets = targets
+  end
+
+  protected
+
+  def method_missing(name, *args, &block)
+    @targets.map do |target|
+      target.__send__(name, *args, &block)
+    end
+  end
+end
+
+log_file_path = "/tmp/codedeploy-agent.update.log"
+
+require 'logger'
+
+if($stdout.isatty)
+  # if we are being run in a terminal, log to stdout and the log file.
+  @log = Logger.new(Proxy.new(File.open(log_file_path, 'a+'), $stdout))
+else
+  # keep at most 2MB of old logs rotating out 1MB at a time
+  @log = Logger.new(log_file_path, 2, 1048576)
+  # make sure anything coming out of ruby ends up in the log file
+  $stdout.reopen(log_file_path, 'a+')
+  $stderr.reopen(log_file_path, 'a+')
+end
+
+@log.level = Logger::INFO
+
+begin
+  require 'fileutils'
+  require 'openssl'
+  require 'open-uri'
+  require 'uri'
+  require 'getoptlong'
+  require 'tempfile'
+
+  def usage
+    print <<EOF
+
+install [--sanity-check] [--proxy http://hostname:port] <package-type>
+   --sanity-check [optional]
+   --proxy [optional]
+   package-type: 'rpm', 'deb', or 'auto'
+
+Installs fetches the latest package version of the specified type and
+installs it. rpms are installed with yum; debs are installed using gdebi.
+
+This program is invoked automatically to update the agent once per day using
+the same package manager the codedeploy-agent is initially installed with.
+
+To use this script for a hands free install on any system specify a package
+type of 'auto'. This will detect if yum or gdebi is present on the system
+and select the one present if possible. If both rpm and deb package managers
+are detected the automatic detection will abort
+When using the automatic setup, if the system has apt-get but not gdebi,
+the gdebi will be installed using apt-get first.
+
+If --sanity-check is specified, the install script will wait for 3 minutes post installation
+to check for a running agent.
+
+To use a HTTP proxy, specify --proxy followed by the proxy server
+defined by http://hostname:port
+
+This install script needs Ruby version 2.x installed as a prerequisite.
+Currently recommanded Ruby versions are 2.0.0, 2.1.8, 2.2.4 and 2.3.0, and 2.4.0.
+If multiple Ruby versions are installed, the default ruby version will be used.
+If the default ruby version does not satisfy reqirement, the newest version will be used.
+If you do not have a supported Ruby version installed, please install one of them first.
+
+EOF
+  end
+
+  def supported_ruby_versions
+    ['2.4', '2.3', '2.2', '2.1', '2.0']
+  end
+
+  # check ruby version, only version 2.x works
+  def check_ruby_version_and_symlink
+    @log.info("Starting Ruby version check.")
+    actual_ruby_version = RUBY_VERSION.split('.').map{|s|s.to_i}[0,2]
+    
+    supported_ruby_versions.each do |version|
+      if ((actual_ruby_version <=> version.split('.').map{|s|s.to_i}) == 0)
+        return File.join(RbConfig::CONFIG["bindir"], RbConfig::CONFIG["RUBY_INSTALL_NAME"] + RbConfig::CONFIG["EXEEXT"])
+      end
+    end
+
+    supported_ruby_versions.each do |version|
+      if(File.exist?("/usr/bin/ruby#{version}"))
+        return "/usr/bin/ruby#{version}"
+      elsif (File.symlink?("/usr/bin/ruby#{version}"))
+          @log.error("The symlink /usr/bin/ruby#{version} exists, but it's linked to a non-existent directory or non-executable file.")
+          exit(1)
+      end
+    end
+
+    unsupported_ruby_version_error    
+    exit(1)
+  end
+
+  def unsupported_ruby_version_error
+    @log.error("Current running Ruby version for "+ENV['USER']+" is "+RUBY_VERSION+", but Ruby version 2.x needs to be installed.")
+    @log.error('If you already have the proper Ruby version installed, please either create a symlink to /usr/bin/ruby2.x,') 
+    @log.error( "or run this install script with right interpreter. Otherwise please install Ruby 2.x for "+ENV['USER']+" user.")
+    @log.error('You can get more information by running the script with --help option.')
+  end
+
+  def parse_args()
+    if (ARGV.length > 4)
+      usage
+      @log.error('Too many arguments.')
+      exit(1)
+    elsif (ARGV.length < 1)
+      usage
+      @log.error('Expected package type as argument.')
+      exit(1)
+    end
+
+    @sanity_check = false
+    @reexeced = false
+    @http_proxy = nil
+
+    @args = Array.new(ARGV)
+    opts = GetoptLong.new(['--sanity-check', GetoptLong::NO_ARGUMENT], ['--help', GetoptLong::NO_ARGUMENT], ['--re-execed', GetoptLong::NO_ARGUMENT], ['--proxy', GetoptLong::OPTIONAL_ARGUMENT])
+    opts.each do |opt, args|
+      case opt
+      when '--sanity-check'
+        @sanity_check = true
+      when '--help'
+        usage
+      when '--re-execed'
+        @reexeced = true
+      when '--proxy'
+        if (args != '')
+          @http_proxy = args
+        end
+      end
+    end
+    if (ARGV.length < 1)
+      usage
+      @log.error('Expected package type as argument.')
+      exit(1)
+    end
+    @type = ARGV.shift.downcase;
+  end
+
+  def force_ruby2x(ruby_interpreter_path)
+    # change interpreter when symlink /usr/bin/ruby2.x exists, but running with non-supported ruby version
+    actual_ruby_version = RUBY_VERSION.split('.').map{|s|s.to_i}
+    left_bound = '2.0.0'.split('.').map{|s|s.to_i}
+    right_bound = '2.4.1'.split('.').map{|s|s.to_i}
+    if (actual_ruby_version <=> left_bound) < 0
+      if(!@reexeced)
+        @log.info("The current Ruby version is not 2.x! Restarting the installer with #{ruby_interpreter_path}")
+        exec("#{ruby_interpreter_path}", __FILE__, '--re-execed' , *@args)
+      else
+        unsupported_ruby_version_error
+        exit(1)
+      end
+    elsif ((actual_ruby_version <=> right_bound) > 0)
+      @log.warn("The Ruby version in #{ruby_interpreter_path} is "+RUBY_VERSION+", . Attempting to install anyway.")
+    end
+  end
+
+  if (Process.uid != 0)
+    @log.error('Must run as root to install packages')
+    exit(1)
+  end
+
+  parse_args()
+
+  ########## Force running as Ruby 2.x or fail here       ##########
+  ruby_interpreter_path = check_ruby_version_and_symlink
+  force_ruby2x(ruby_interpreter_path)
+
+  def run_command(*args)
+    exit_ok = system(*args)
+    $stdout.flush
+    $stderr.flush
+    @log.debug("Exit code: #{$?.exitstatus}")
+    return exit_ok
+  end
+
+  def get_ec2_metadata_region
+    begin
+      uri = URI.parse('http://169.254.169.254/latest/meta-data/placement/availability-zone')
+      az = uri.read(:read_timeout => 120)
+      az.strip
+    rescue
+      @log.warn("Could not get region from EC2 metadata service at '#{uri.to_s}'")
+      return nil
+    end
+
+    if (az !~ /[a-z]{2}-[a-z]+-\d+[a-z]/)
+      @log.warn("Invalid availability zone name: '#{az}'.")
+      return nil
+    else
+      return az.chop
+    end
+  end
+
+  def get_region
+    @log.info('Checking AWS_REGION environment variable for region information...')
+    region = ENV['AWS_REGION']
+    return region if region
+
+    @log.info('Checking EC2 metadata service for region information...')
+    region = get_ec2_metadata_region
+    return region if region
+
+    @log.info('Using fail-safe default region: us-east-1')
+    return 'us-east-1'
+  end
+
+  def get_s3_uri(region, bucket, key)
+    if (region == 'us-east-1')
+      URI.parse("https://#{bucket}.s3.amazonaws.com/#{key}")
+    elsif (region.split("-")[0] == 'cn')
+      URI.parse("https://#{bucket}.s3.#{region}.amazonaws.com.cn/#{key}")
+    else
+      URI.parse("https://#{bucket}.s3-#{region}.amazonaws.com/#{key}")
+    end
+  end
+
+  def get_package_from_s3(region, bucket, key, package_file)
+    @log.info("Downloading package from bucket #{bucket} and key #{key}...")
+
+    uri = get_s3_uri(region, bucket, key)
+
+    # stream package file to disk
+    begin
+      uri.open(:ssl_verify_mode => OpenSSL::SSL::VERIFY_PEER, :redirect => true, :read_timeout => 120, :proxy => @http_proxy) do |s3|
+        package_file.write(s3.read)
+      end
+    rescue OpenURI::HTTPError => e
+      @log.error("Could not find package to download at '#{uri.to_s}'")
+      exit(1)
+    end
+  end
+
+  def get_version_file_from_s3(region, bucket, key)
+    @log.info("Downloading version file from bucket #{bucket} and key #{key}...")
+
+    uri = get_s3_uri(region, bucket, key)
+
+    begin
+      require 'json'
+
+      version_string = uri.read(:ssl_verify_mode => OpenSSL::SSL::VERIFY_PEER, :redirect => true, :read_timeout => 120, :proxy => @http_proxy)
+      JSON.parse(version_string)
+    rescue OpenURI::HTTPError => e
+      @log.error("Could not find version file to download at '#{uri.to_s}'")
+      exit(1)
+    end
+  end
+
+  def install_from_s3(region, bucket, version_file_key, type, install_cmd)
+    version_data = get_version_file_from_s3(region, bucket, version_file_key)
+
+    package_key = version_data[type]
+    package_base_name = File.basename(package_key)
+    package_extension = File.extname(package_base_name)
+    package_name = File.basename(package_base_name, package_extension)
+    package_file = Tempfile.new(["#{package_name}.tmp-", package_extension]) # unique file with 0600 permissions
+
+    get_package_from_s3(region, bucket, package_key, package_file)
+    package_file.close
+
+    install_cmd << package_file.path
+    @log.info("Executing `#{install_cmd.join(" ")}`...")
+
+    if (!run_command(*install_cmd))
+      @log.error("Error installing #{package_file.path}.")
+      package_file.unlink
+      exit(1)
+    end
+
+    package_file.unlink
+  end
+
+  def do_sanity_check(cmd)
+    if @sanity_check
+      @log.info("Waiting for 3 minutes before I check for a running agent")
+      sleep(3 * 60)
+      res = run_command(cmd, 'codedeploy-agent', 'status')
+      if (res.nil? || res == false)
+        @log.info("No codedeploy agent seems to be running. Starting the agent.")
+        run_command(cmd, 'codedeploy-agent', 'start-no-update')
+      end
+    end
+  end
+
+  @log.info("Starting update check.")
+
+  if (@type == 'auto')
+    @log.info('Attempting to automatically detect supported package manager type for system...')
+
+    has_yum = run_command('which yum >/dev/null 2>/dev/null')
+    has_apt_get = run_command('which apt-get >/dev/null 2>/dev/null')
+    has_gdebi = run_command('which gdebi >/dev/null 2>/dev/null')
+    has_zypper = run_command('which zypper >/dev/null 2>/dev/null')
+
+    if (has_yum && (has_apt_get || has_gdebi))
+      @log.error('Detected both supported rpm and deb package managers. Please specify which package type to use manually.')
+      exit(1)
+    end
+
+    if(has_yum)
+      @type = 'rpm'
+    elsif(has_zypper)
+      @type = 'zypper'
+    elsif(has_gdebi)
+      @type = 'deb'
+    elsif(has_apt_get)
+      @type = 'deb'
+
+      @log.warn('apt-get found but no gdebi. Installing gdebi with `apt-get install gdebi-core -y`...')
+      #use -y to answer yes to confirmation prompts
+      if(!run_command('/usr/bin/apt-get', 'install', 'gdebi-core', '-y'))
+        @log.error('Could not install gdebi.')
+        exit(1)
+      end
+    else
+      @log.error('Could not detect any supported package managers.')
+      exit(1)
+    end
+  end
+
+  region = get_region
+  bucket = "aws-codedeploy-#{region}"
+  version_file_key = 'latest/VERSION'
+
+  case @type
+  when 'help'
+    usage
+  when 'rpm'
+    running_version = `rpm -q codedeploy-agent`
+    running_version.strip!
+    target_version = get_version_file_from_s3(region, bucket, version_file_key)['rpm']
+    if target_version.include? running_version
+      @log.info('Running version matches target version, skipping install')
+    else
+      #use -y to answer yes to confirmation prompts
+      install_cmd = ['/usr/bin/yum', '-y', 'localinstall']
+      install_from_s3(region, bucket, version_file_key, @type, install_cmd)
+      do_sanity_check('/sbin/service')
+    end
+  when 'deb'
+    running_agent = `dpkg -s codedeploy-agent`
+    running_agent_info = running_agent.split
+    version_index = running_agent_info.index('Version:')
+    if !version_index.nil?
+      running_version = running_agent_info[version_index + 1]
+    else
+      running_version = "No running version"
+    end
+    @log.info("Running version " + running_version)
+    target_version = get_version_file_from_s3(region, bucket, version_file_key)['deb']
+    if target_version.include? running_version
+      @log.info('Running version matches target version, skipping install')
+    else
+      #use -n for non-interactive mode
+      #use -o to not overwrite config files unless they have not been changed
+      install_cmd = ['/usr/bin/gdebi', '-n', '-o', 'Dpkg::Options::=--force-confdef', '-o', 'Dkpg::Options::=--force-confold']
+      install_from_s3(region, bucket, version_file_key, @type, install_cmd)
+      do_sanity_check('/usr/sbin/service')
+    end
+  when 'zypper'
+    #use -n for non-interactive mode
+    install_cmd = ['/usr/bin/zypper', 'install', '-n']
+    install_from_s3(region, bucket, version_file_key, 'rpm', install_cmd)
+  else
+    @log.error("Unsupported package type '#{@type}'")
+    exit(1)
+  end
+
+  @log.info("Update check complete.")
+  @log.info("Stopping updater.")
+
+rescue SystemExit => e
+  # don't log exit() as an error
+  raise e
+rescue Exception => e
+  # make sure all unhandled exceptions are logged to the log
+  @log.error("Unhandled exception: #{e.inspect}")
+  e.backtrace.each do |line|
+    @log.error("  at " + line)
+  end
+  exit(1)
+end


### PR DESCRIPTION
Amazon support a limited set of Linux distributions with the provided install
script, and that set does not include Arch Linux.

Internally the install script works out where to download things from S3, and
chooses the latest version of the CodeDeploy agent by parsing a JSON manifest
also stored on S3. More information on how installation works can be found in
the README I've included.

Currently the Ruby-based agent will be installed to `/opt`, as you'd expect with
this kind of self-contained application. There's a configuration file that I've
put where Amazon put it in `/etc/codedeploy-agent/conf/codedeployagent.yml`,
and a systemd unit file that will manage the agent for you.

I haven't tweaked any of the configuration defaults, which means the agent will
log to a file etc.

``` yaml
---
:log_aws_wire: false
:log_dir: '/var/log/aws/codedeploy-agent/'
:pid_dir: '/opt/codedeploy-agent/state/.pid/'
:program_name: codedeploy-agent
:root_dir: '/opt/codedeploy-agent/deployment-root'
:verbose: false
:wait_between_runs: 1
:proxy_uri:
:max_revisions: 5
```