### PR TITLE
Update out of date package checksum

### DIFF
--- a/share/journald-cloud-watch-script/PKGBUILD
+++ b/share/journald-cloud-watch-script/PKGBUILD
@@ -10,7 +10,7 @@ groups=()
 depends=('aws-cli' 'bash' 'jq')
 source=(tail-journald
         journald-cloud-watch-script.service)
-md5sums=('8907d8a5eadddd7c36730b4e7eff0f11'
+md5sums=('3aae47c41ec1493ccce91611fb52dd6e'
          '957ed4f7b25b8246aa518aee1474a20e')
 
 package() {


### PR DESCRIPTION
I noticed that the AMI would no longer build because of a validity check failure of the journald-cloud-watch-script package. 

Some changes (https://github.com/juxt/rock/commit/55bc067a4a062fa90e97eaf0aba390a352565860) made to `tail-journald` require an updated checksum to be generated. 

This pull request is to generate the new checksum.