### PR TITLE
Production feedback

### DIFF
--- a/rock.json
+++ b/rock.json
@@ -9,7 +9,7 @@
         {
             "type": "amazon-ebs",
             "region": "eu-west-2",
-            "source_ami": "ami-210be846",
+            "source_ami": "ami-f57a9292",
             "instance_type": "t2.small",
             "ssh_username": "root",
             "ami_name": "juxt-rock-{{user `commit_ref`}}-{{timestamp}}"

--- a/scripts/install-cfn-bootstrap.sh
+++ b/scripts/install-cfn-bootstrap.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -eux
+
+pacman --noconfirm -Syu "python2"
+
+working_dir="/tmp/aws-cfn-bootstrap"
+
+mkdir -p "$working_dir"
+
+cd "$working_dir"
+wget https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-1.4-30.tar.gz
+
+tar xzf aws-cfn-bootstrap*.tar.gz
+cd aws-cfn-bootstrap-1*/
+
+sed -i "s/env python'/env python2'/" setup.py
+python2 setup.py install
+
+rm -rf "$working_dir"

--- a/scripts/install-custom.sh
+++ b/scripts/install-custom.sh
@@ -64,6 +64,11 @@ chmod -R 774 "$PKG_DIR"
 # containing PKGBUILD files.
 cd "$PKG_DIR"
 
+# Dependencies from AUR of our packages need fetching in order to be available
+# for builds.  Currently there doesn't appear to be a way to automatically get
+# list.
+echo 'python2-pystache' | su --preserve-environment -c 'aurfetch' rock
+
 # Packages in AUR etc. have both a `PKGBUILD` file and a `.SRCINFO`. As we don't
 # want to have to remember to create this src info file everytime we edit a
 # package definition we create the files only when we need them.
@@ -80,7 +85,8 @@ build_pkgs
 install_pkgs \
     codedeploy-agent \
     journald-cloud-watch-script \
-    systemd-cloud-watch
+    systemd-cloud-watch \
+    aws-cfn-bootstrap
 
 # To install any packages from the AUR can now be done like so:
 #     aursync <pkg0> <pkg1> <pkg2> ...

--- a/share/aws-cfn-bootstrap/PKGBUILD
+++ b/share/aws-cfn-bootstrap/PKGBUILD
@@ -1,0 +1,25 @@
+pkgname=aws-cfn-bootstrap
+pkgver=1.4_30
+pkgrel=1
+pkgdesc=""
+arch=('i686' 'x86_64')
+url='https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-helper-scripts-reference.html'
+license=('Apache-2.0')
+# TODO: python2-pystache is only in the AUR, how do we handle that?
+depends=('python2-pystache')
+# >=1.5.2,<2.0
+optdepends=('python2-daemon: Support for running cfn-hup as a daemon')
+makedepends=('python2-setuptools')
+source=(https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-${pkgver//_/-}.tar.gz)
+md5sums=('5715176852b84761c63097f2778c99e4')
+
+build() {
+  cd $pkgname-${pkgver/_*/}
+  python2 setup.py build
+}
+
+package() {
+  cd $pkgname-${pkgver/_*/}
+  python2 setup.py install --root="$pkgdir" --optimize=1
+  sed -i "s|#!/usr/bin/env python$|#!/usr/bin/env python2|" ${pkgdir}/usr/bin/*
+}

--- a/share/journald-cloud-watch-script/PKGBUILD
+++ b/share/journald-cloud-watch-script/PKGBUILD
@@ -11,7 +11,7 @@ depends=('aws-cli' 'bash' 'jq')
 source=(tail-journald
         journald-cloud-watch-script.service
         journald-cloud-watch-script.install)
-md5sums=('83e4e0bf9b02fa5eec2e692de362cf29'
+md5sums=('b561e5e0aab3eb3c44f6919e2acec2b3'
          '553401317d43abbd4b0147b7bec5820d'
          '7a25597c93a176efede06b2c551ab534')
 install=journald-cloud-watch-script.install

--- a/share/journald-cloud-watch-script/PKGBUILD
+++ b/share/journald-cloud-watch-script/PKGBUILD
@@ -11,7 +11,7 @@ depends=('aws-cli' 'bash' 'jq')
 source=(tail-journald
         journald-cloud-watch-script.service)
 md5sums=('8907d8a5eadddd7c36730b4e7eff0f11'
-         '957ed4f7b25b8246aa518aee1474a20e')
+         '553401317d43abbd4b0147b7bec5820d')
 
 package() {
   cd "$srcdir"

--- a/share/journald-cloud-watch-script/PKGBUILD
+++ b/share/journald-cloud-watch-script/PKGBUILD
@@ -9,9 +9,12 @@ license=('GPL')
 groups=()
 depends=('aws-cli' 'bash' 'jq')
 source=(tail-journald
-        journald-cloud-watch-script.service)
-md5sums=('8907d8a5eadddd7c36730b4e7eff0f11'
-         '553401317d43abbd4b0147b7bec5820d')
+        journald-cloud-watch-script.service
+        journald-cloud-watch-script.install)
+md5sums=('83e4e0bf9b02fa5eec2e692de362cf29'
+         '553401317d43abbd4b0147b7bec5820d'
+         '7a25597c93a176efede06b2c551ab534')
+install=journald-cloud-watch-script.install
 
 package() {
   cd "$srcdir"

--- a/share/journald-cloud-watch-script/journald-cloud-watch-script.install
+++ b/share/journald-cloud-watch-script/journald-cloud-watch-script.install
@@ -1,0 +1,13 @@
+post_install() {
+  if ! getent group cw-journald >/dev/null; then
+    groupadd cw-journald
+  fi
+  if ! getent passwd cw-journald >/dev/null; then
+    useradd -c 'CloudWatch Journald Script User' -g cw-journald -G systemd-journal -s /bin/nologin cw-journald
+    passwd -l cw-journald >/dev/null
+  fi
+  if [ ! -d '/var/lib/journald-cloud-watch-script' ]; then
+    mkdir -p '/var/lib/journald-cloud-watch-script'
+    chown cw-journald:cw-journald '/var/lib/journald-cloud-watch-script'
+  fi
+}

--- a/share/journald-cloud-watch-script/journald-cloud-watch-script.service
+++ b/share/journald-cloud-watch-script/journald-cloud-watch-script.service
@@ -4,8 +4,8 @@ Wants=basic.target
 After=basic.target network.target
 
 [Service]
-User=nobody
-Group=nobody
+User=cw-journald
+Group=cw-journald
 ExecStart=/usr/bin/tail-journald
 KillMode=process
 Restart=on-failure

--- a/share/journald-cloud-watch-script/tail-journald
+++ b/share/journald-cloud-watch-script/tail-journald
@@ -30,7 +30,8 @@ create_or_get_current_cursor () {
         aws logs create-log-stream \
             --region=$AWS_REGION \
             --log-group-name=$LOG_GROUP_NAME \
-            --log-stream-name=$LOG_STREAM_NAME
+            --log-stream-name=$LOG_STREAM_NAME \
+            || return 0
     fi
 }
 

--- a/share/journald-cloud-watch-script/tail-journald
+++ b/share/journald-cloud-watch-script/tail-journald
@@ -50,7 +50,17 @@ journal_cursor_rows () {
 }
 
 format_row () {
-    jq "{timestamp: $(date +%s%3N), message: @json}"
+    jq '
+    # A fork of jq 1.6 walk which also walks over the keys
+    def walk(f):
+      . as $in
+      | if type == "object" then
+          reduce keys[] as $key
+          ( {}; . + { ($key | walk(f)):  ($in[$key] | walk(f)) } ) | f
+      elif type == "array" then map( walk(f) ) | f
+      else f
+      end;
+  {timestamp: '"$(date +%s%3N)"', message: @json "\(walk(if type == "string" then .[:16384] else . end))"}'
 }
 
 write_batch () {
@@ -65,6 +75,7 @@ write_batch () {
     else
         sequence_token=""
     fi
+
     aws logs put-log-events \
         --region="$AWS_REGION" \
         --log-group-name="$LOG_GROUP_NAME" \

--- a/share/journald-cloud-watch-script/tail-journald
+++ b/share/journald-cloud-watch-script/tail-journald
@@ -60,9 +60,6 @@ write_batch () {
         return 0
     fi
 
-    BATCH=$(echo "$rows" |\
-        format_row |\
-        jq -s .)
     if [[ $(cat $AWS_CURSOR_FILE) ]]; then
         sequence_token="--sequence-token=$(cat $AWS_CURSOR_FILE)"
     else
@@ -73,7 +70,7 @@ write_batch () {
         --log-group-name="$LOG_GROUP_NAME" \
         --log-stream-name="$LOG_STREAM_NAME" \
         "$sequence_token" \
-        --log-events="$BATCH" |\
+        --log-events 'file://'<(echo "$rows" | format_row | jq -s .)|\
         jq -r ".nextSequenceToken" > "$AWS_CURSOR_FILE"
 }
 

--- a/terraform/rock.sh
+++ b/terraform/rock.sh
@@ -16,3 +16,6 @@ EOF
 #
 # Fix is in this PR: https://github.com/advantageous/systemd-cloud-watch/pull/16
 # systemctl start systemd-cloud-watch
+
+# Fortunately there's an alternative bash script
+systemctl start journald-cloud-watch-script


### PR DESCRIPTION
Changes:

bac4641 (Dominic Monroe, 5 days ago)
   Add aws-cfn-bootstrap package

   The contained cfn-signal is required for performing rolling changes to
   launch configurations.  Without cfn-signal you will not know when the host
   has launched successfully and completely.

98e1993 (Dominic Monroe, 2 weeks ago)
   Fix permissions for cloudwatch script

   Uses an install strongly borrowing from the postgres official arch package.
    This creates a user and configures directory permissions for it.  Without
   this, the /var/ state directory that tail-journald uses is not writable for
   the script.

48b89c0 (Dominic Monroe, 2 weeks ago)
   Ignore failure when creating log-stream

   The script can fail in such a way that it does not write a cursor, but has
   created a log stream.  In this case, creating a log stream a second time
   will fail.  This can be easily ignored.

58182bd (Dominic Monroe, 7 weeks ago)
   Enable journald cloud watch script by default