### PR TITLE
Fix Reflector Config

### DIFF
--- a/rock.edn
+++ b/rock.edn
@@ -8,7 +8,9 @@
    "region" "eu-west-2"
    ;; Seems that Arch EC2 optimized isn't doesn't respond to SSH, so
    ;; using the Arch Std kernel instead for now.
-   "source_ami" "ami-01b47269638a6aad8"
+   ;; Old arch images are not maintained. Current list available at
+   ;; https://wiki.archlinux.org/title/Arch_Linux_AMIs_for_Amazon_Web_Services
+   "source_ami" "ami-013df715cca13bc87"
    "instance_type" "t2.large"
    "ssh_username" "arch"
    "ami_name" "juxt-rock-{{user `commit_ref`}}-{{timestamp}}"}]

--- a/scripts/pacman-key.sh
+++ b/scripts/pacman-key.sh
@@ -4,4 +4,6 @@ set -eux
 
 pacman-key --init
 pacman-key --populate
-reflector --country "GB" --protocol https,http --score 20 --sort rate --save /etc/pacman.d/mirrorlist
+reflector --country GB,FR,DE --protocol https,http --age 72 --score 30 -n 20 --sort rate --save /etc/pacman.d/mirrorlist
+sudo pacman --noconfirm -Sy archlinux-keyring
+sudo pacman --noconfirm -Syu


### PR DESCRIPTION
Previously we were looking for the top 20 Great Britain servers for pacman mirrors, but there weren't 20 GB servers available and some of the ones that were available were very out of date. This PR expands the net to include France and Germany and also sets a minimum age.